### PR TITLE
80 allow for custom event types

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    if: github.ref != 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x
@@ -28,7 +28,7 @@ jobs:
         run: npm run lint
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    if: github.ref != 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -40,7 +40,21 @@ jobs:
         run: npm install -g npm
       - name: NPM Install
         run: npm ci
-      - name: Lint
-        run: npm run lint
       - name: Build
         run: npm run build
+  test:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main' && github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'npm'
+      - name: Update NPM
+        run: npm install -g npm
+      - name: NPM Install
+        run: npm ci
+      - name: Test
+        run: npm run test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint
+npm run test

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ The following commands are used for development:
 | `npm run test`     | Run Jest unit tests for Schedulely                                        |
 | `npm run dev-docs` | Run Docusaurus documentation with real-time updates.                      |
 
-## Documentation Development
+### Documentation Development
 
 The documentation project builds `Schedulely` and adds it directly to the documentation pages. It does _not_ utilize a released NPM package. This ensures that the documentation always reflects exactly what is on main, and doesn't require us to continually keep bumping the Schedulely package version between releases.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ The following commands are used for development:
 | `npm run dev`      | Run Schedulely within Ladle. This is used for real-time local development |
 | `npm run test`     | Run Jest unit tests for Schedulely                                        |
 | `npm run dev-docs` | Run Docusaurus documentation with real-time updates.                      |
+
+## Documentation Development
+
+The documentation project builds `Schedulely` and adds it directly to the documentation pages. It does _not_ utilize a released NPM package. This ensures that the documentation always reflects exactly what is on main, and doesn't require us to continually keep bumping the Schedulely package version between releases.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,23 @@ The included default calendar components can be simply used as is, but the real 
 
 ## Development
 
+### Projects
+
+| location                 | description                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| `./packages/Schedulely`  | The Schedulely component that is used to create the NPM package              |
+| `./apps/schedulely-docs` | The Docusaurus project that contains the formal documentation for Schedulely |
+
+### Turborepo
+
 These project uses Turborepo for building, so many of these tasks are additive and will call other tasks.
 
 The following commands are used for development:
 
-| command    | description                                                               |
-| ---------- | ------------------------------------------------------------------------- |
-| `build`    | Build all artifacts                                                       |
-| `rollup`   | Build the Schedulely NPM package artifact                                 |
-| `dev`      | Run Schedulely within Ladle. This is used for real-time local development |
-| `test`     | Run Jest unit tests                                                       |
-| `dev-docs` | Run Docusaurus documentation with real-time updates.                      |
+| command            | description                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| `npm run build`    | Build all artifacts (Schedulely and docs)                                 |
+| `npm run rollup`   | Build the Schedulely NPM package artifact                                 |
+| `npm run dev`      | Run Schedulely within Ladle. This is used for real-time local development |
+| `npm run test`     | Run Jest unit tests for Schedulely                                        |
+| `npm run dev-docs` | Run Docusaurus documentation with real-time updates.                      |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _This component is still very early in development. Everything is currently stil
 
 ---
 
-[![npm](https://img.shields.io/npm/v/schedulely)](https://www.npmjs.com/package/schedulely) [![npm bundle size](https://img.shields.io/bundlephobia/minzip/schedulely)](https://bundlephobia.com/package/schedulely) [![install size](https://packagephobia.com/badge?p=schedulely)](https://packagephobia.com/result?p=schedulely) ![NPM](https://img.shields.io/npm/l/schedulely?color=blue)
+[![npm](https://img.shields.io/npm/v/schedulely)](https://www.npmjs.com/package/schedulely) [![npm bundle size](https://img.shields.io/bundlephobia/minzip/schedulely)](https://bundlephobia.com/package/schedulely) ![NPM](https://img.shields.io/npm/l/schedulely?color=blue)
 
 ## 📃 Description
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The included default calendar components can be simply used as is, but the real 
 
 ### Turborepo
 
-These project uses Turborepo for building, so many of these tasks are additive and will call other tasks.
+This project uses Turborepo for building, so many of these tasks are additive and will call other tasks.
 
 The following commands are used for development:
 

--- a/apps/schedulely-docs/docs/Components/Day.md
+++ b/apps/schedulely-docs/docs/Components/Day.md
@@ -9,7 +9,7 @@ The `DayComponent` is used to display individual days on the calendar grid. Vari
 ## Component Props
 
 ```tsx
-export interface DayComponentProps {
+export interface DayComponentProps<T extends object = {}> {
   isCurrentMonth: boolean;
   date: Date;
   isToday: boolean;

--- a/apps/schedulely-docs/docs/Components/Day.md
+++ b/apps/schedulely-docs/docs/Components/Day.md
@@ -74,7 +74,7 @@ const DefaultDay = ({
         <div
           className="additional-events-indicator"
           title={hiddenEventTooltip}
-          onClick={() => onMoreEventsClick(JSON.stringify(events))}
+          onClick={() => onMoreEventsClick(JSON.stringify(events, null, 2))}
         >
           ...
         </div>

--- a/apps/schedulely-docs/docs/Components/Day.md
+++ b/apps/schedulely-docs/docs/Components/Day.md
@@ -113,3 +113,10 @@ render(
   </div>
 );
 ```
+
+## Custom Day Component
+
+The `DayComponent` also has an optional generic parameter that can be used to enfore strong-typing of the `data` property. This can be leveraged if writing
+your own custom DayComponent.
+
+More information can be found on the [Custom Event Data Page](/docs/Usage/CustomEventData).

--- a/apps/schedulely-docs/docs/Components/Day.md
+++ b/apps/schedulely-docs/docs/Components/Day.md
@@ -83,7 +83,21 @@ const DefaultDay = ({
   );
 };
 
-const events = [...generateEvents(2)];
+// simulate fetching events from somewhere
+const events = [
+  ...generateEvents(2),
+  {
+    id: '1',
+    start: new Date(),
+    end: new Date(),
+    summary: 'This is an event',
+    color: 'lightblue',
+    data: {
+      extraProp1: 1,
+      extraProp2: 'some-more-data',
+    },
+  },
+];
 
 render(
   <div className="schedulely" style={{ height: '7em', width: '7em' }}>

--- a/apps/schedulely-docs/docs/Components/Day.md
+++ b/apps/schedulely-docs/docs/Components/Day.md
@@ -14,21 +14,21 @@ export interface DayComponentProps {
   date: Date;
   isToday: boolean;
   isOverflowed: boolean;
-  events: InternalCalendarEvent[];
-  onMoreEventsClick: (event: InternalCalendarEvent[]) => void;
+  events: InternalCalendarEvent<T>[];
+  onMoreEventsClick: (event: InternalCalendarEvent<T>[]) => void;
   onDayClick: (day: Date) => void;
 }
 ```
 
-| Property          | Type                                       | Description                                                                     |
-| ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------- |
-| isCurrentMonth    | `boolean`                                  | True if this date occurs in the current visible month                           |
-| isToday           | `boolean`                                  | True is this date is equal to today's date                                      |
-| date              | `Date`                                     | JS Date object for the day                                                      |
-| events            | `InternalCalendarEvent[]`                  | Array of _all_ events that occur or span this date (both hidden and visible)    |
-| isOverflowed      | `boolean`                                  | True if the date has more events than can visible fit. (Some events are hidden) |
-| onMoreEventsClick | `(event: InternalCalendarEvent[]) => void` | This function should be called whenever the 'More Events' indicator is clicked  |
-| onDayClick        | `(day: Date) => void`                      | This function should be called whenever a Day Component is clicked on           |
+| Property          | Type                                          | Description                                                                     |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------- |
+| isCurrentMonth    | `boolean`                                     | True if this date occurs in the current visible month                           |
+| isToday           | `boolean`                                     | True is this date is equal to today's date                                      |
+| date              | `Date`                                        | JS Date object for the day                                                      |
+| events            | `InternalCalendarEvent<T>[]`                  | Array of _all_ events that occur or span this date (both hidden and visible)    |
+| isOverflowed      | `boolean`                                     | True if the date has more events than can visible fit. (Some events are hidden) |
+| onMoreEventsClick | `(event: InternalCalendarEvent<T>[]) => void` | This function should be called whenever the 'More Events' indicator is clicked  |
+| onDayClick        | `(day: Date) => void`                         | This function should be called whenever a Day Component is clicked on           |
 
 ## Dealing with hidden events
 

--- a/apps/schedulely-docs/docs/Components/Event.md
+++ b/apps/schedulely-docs/docs/Components/Event.md
@@ -8,21 +8,27 @@ The `EventComponent` how events are displayed within Schedulely. The `EventCompo
 internally based on the start/end of the event. The `hover` effect is also handled internally, so all you need to do is describe what action should be taken if
 the event happens to be hovered.
 
+### Extra Event Data
+
+Additional data can be passed in by utilizing the `data` property on the `CalendarEvent` type.
+If using Typescript, you can passing the generic parameter to get strong-typing in your components. This isn't strictly necessary, but it is helpful if you are
+creating a custom Event component.
+
 ## Component Props
 
 ```tsx
-export interface EventComponentProps {
-  event: InternalCalendarEvent;
+export interface EventComponentProps<T extends object = {}> {
+  event: InternalCalendarEvent<T>;
   isHovered: boolean;
-  onClick: (event: InternalCalendarEvent) => void;
+  onClick: (event: InternalCalendarEvent<T>) => void;
 }
 ```
 
-| Property  | Type                                     | Description                                                             |
-| --------- | ---------------------------------------- | ----------------------------------------------------------------------- |
-| event     | `InternalCalendarEvent`                  | The event that this component represents                                |
-| isHovered | `boolean`                                | True when event is hovered. Default behavior is used to highlight event |
-| onClick   | `(event: InternalCalendarEvent) => void` | Function executes when the event is clicked                             |
+| Property  | Type                                        | Description                                                             |
+| --------- | ------------------------------------------- | ----------------------------------------------------------------------- |
+| event     | `InternalCalendarEvent<T>`                  | The event that this component represents                                |
+| isHovered | `boolean`                                   | True when event is hovered. Default behavior is used to highlight event |
+| onClick   | `(event: InternalCalendarEvent<T>) => void` | Function executes when the event is clicked                             |
 
 ## Example (DefaultEvent)
 
@@ -54,6 +60,10 @@ const event = {
   end: new Date(),
   summary: 'This is an event',
   color: 'lightblue',
+  data: {
+    extraProp1: 1,
+    extraProp2: 'some-more-data',
+  },
 };
 
 render(

--- a/apps/schedulely-docs/docs/Components/Event.md
+++ b/apps/schedulely-docs/docs/Components/Event.md
@@ -76,3 +76,10 @@ render(
   </div>
 );
 ```
+
+## Custom Event Component
+
+The `EventComponent` also has an optional generic parameter that can be used to enfore strong-typing of the `data` property. This can be leveraged if writing
+your own custom EventComponent.
+
+More information can be found on the [Custom Event Data Page](/docs/Usage/CustomEventData).

--- a/apps/schedulely-docs/docs/Usage/Actions.md
+++ b/apps/schedulely-docs/docs/Usage/Actions.md
@@ -21,7 +21,7 @@ By default, the actions will print their target Events in to the javascript cons
 
 ## Default Actions
 
-All actions return `() => null` unless explicitly overridden. This is effectively a no-op, and all action handlers can be considered disabled.
+By default, all actions return `() => null` unless explicitly overridden. This equates to a no-op, so any event handlers can be considered disabled unless expressly defined.
 
 ## Setting Custom Actions
 

--- a/apps/schedulely-docs/docs/Usage/Actions.md
+++ b/apps/schedulely-docs/docs/Usage/Actions.md
@@ -8,8 +8,6 @@ The ActionProvider is used under the hood to take in functions as arguments and 
 Schedulely simple, and ensures we are re-rendering the bare minimum. If you are creating custom calendar components, these actions are available to you on each components
 respective interface, and can be implemented(or not implemented) however you choose.
 
-**All actions return `() => null` unless explicitly overridden.**
-
 ## Provided Actions
 
 By default, the actions will print their target Events in to the javascript console.
@@ -23,27 +21,15 @@ By default, the actions will print their target Events in to the javascript cons
 
 ## Default Actions
 
-The default behavior will just print Event information to the javascript console. This behavior is intended to be overridden.
-
-```tsx live noInline
-// This demo is an example of what a custom component might look like if you wanted to override the default.
-// If you are using the default components, you don't need to worry about this.
-
-const events = [...generateEvents(100), ...generateEvents(100, 0, 1, 100)];
-
-render(
-  <Schedulely events={events} dark={localStorage.getItem('theme') === 'dark'} />
-);
-```
+All actions return `() => null` unless explicitly overridden. This is effectively a no-op, and all action handlers can be considered disabled.
 
 ## Setting Custom Actions
 
 Action behavior can be easily set by passing in a function for the desired action when initializing Schedulely.
 
-This simple example replaces the default `console.log` action action with `alert`.
+This simple example replaces the default `() => null` action action with `alert`.
 
 ```tsx live noInline
-/* array of CalendarEvents */
 const events = [...generateEvents(100), ...generateEvents(100, 0, 1, 100)];
 
 render(
@@ -51,34 +37,31 @@ render(
     events={events}
     dark={localStorage.getItem('theme') === 'dark'}
     actions={{
-      onEventClick: (event) => alert(JSON.stringify(event)),
-      onMoreEventClick: (events) => alert(JSON.stringify(events)),
+      onEventClick: (event) => alert(JSON.stringify(event, null, 2)),
+      onMoreEventClick: (events) => alert(JSON.stringify(events, null, 2)),
+    }}
+  />
+);
+```
+
+Similarly, you could also print info to the console:
+
+```tsx live noInline
+const events = [...generateEvents(100), ...generateEvents(100, 0, 1, 100)];
+
+render(
+  <Schedulely
+    events={events}
+    dark={localStorage.getItem('theme') === 'dark'}
+    actions={{
+      onEventClick: (event) => console.log(event),
+      onMoreEventClick: (events) => console.log(events),
     }}
   />
 );
 ```
 
 This principal could easily be expanded upon to display an information modal with more details about that particular event. We leave this implementation up to you.
-
-## Disabling Actions
-
-If you have no need for custom actions(or otherwise), the default `console.log` actions can easily be disabled by having them simply return `null`.
-
-```tsx live noInline
-/* array of CalendarEvents */
-const events = [...generateEvents(100), ...generateEvents(100, 0, 1, 100)];
-
-render(
-  <Schedulely
-    events={events}
-    dark={localStorage.getItem('theme') === 'dark'}
-    actions={{
-      onEventClick: (event) => null,
-      onMoreEventClick: (events) => null,
-    }}
-  />
-);
-```
 
 ## Custom Components and Actions
 

--- a/apps/schedulely-docs/docs/Usage/Actions.md
+++ b/apps/schedulely-docs/docs/Usage/Actions.md
@@ -38,7 +38,7 @@ render(
     dark={localStorage.getItem('theme') === 'dark'}
     actions={{
       onEventClick: (event) => alert(JSON.stringify(event, null, 2)),
-      onMoreEventClick: (events) => alert(JSON.stringify(events, null, 2)),
+      onMoreEventsClick: (events) => alert(JSON.stringify(events, null, 2)),
     }}
   />
 );
@@ -55,7 +55,7 @@ render(
     dark={localStorage.getItem('theme') === 'dark'}
     actions={{
       onEventClick: (event) => console.log(event),
-      onMoreEventClick: (events) => console.log(events),
+      onMoreEventsClick: (events) => console.log(events),
     }}
   />
 );

--- a/apps/schedulely-docs/docs/Usage/CustomEventData.md
+++ b/apps/schedulely-docs/docs/Usage/CustomEventData.md
@@ -1,0 +1,68 @@
+---
+title: Custom Event Data
+description: Supply additional event metadata
+---
+
+If you want to pass additional data to each event object, you can define the `data` property by supplying the generic parameter of `CalendarEvent`. This can be useful if you create custom Day or Event components.
+
+**The default Day/Event components will not display the custom data, though it _will_ be available through `onClick` handlers.**
+
+```tsx
+// custom `data` prop type
+type MyCustomData = { customProp1: boolean };
+
+// event data
+const storyEvents: CalendarEvent<MyCustomData>[] = [
+  {
+    color: '#4b578a',
+    end: '2022-09-09T16:07:22.292Z',
+    id: 'f147',
+    start: '2022-09-08T16:07:22.292Z',
+    summary: 'Craig Bishop',
+    data: {
+      customProp1: true,
+    },
+  },
+];
+
+/**
+ * This is a custom event component that has a strongly-typed `data` prop.
+ * It will print the customProp value to the console
+ */
+export const CustomEvent: EventComponent<MyCustomData> = ({
+  event,
+  isHovered,
+  onClick,
+}) => {
+  const classes = ['event'];
+  if (isHovered) classes.push('event-selected');
+
+  console.log(event.data?.customProp); // <-- props are strongly typed
+
+  return (
+    <div
+      role={'listitem'}
+      data-eventid={event.id}
+      className={classes.join(' ')}
+      style={{
+        backgroundColor: event.color,
+      }}
+      title={event.summary}
+      onClick={() => onClick(event)}
+    >
+      <div className="event-text-container">{event.summary}</div>
+    </div>
+  );
+};
+
+// include schedulely with the event data and the Event component over-ridden
+<Schedulely
+  events={storyEvents}
+  dark={colorMode === 'dark'}
+  theme={theme}
+  schedulelyComponents={{ eventComponent: CustomEvent }}
+/>;
+```
+
+This can be particularly useful when creating custom Event and Day components that makes use of this custom data. Both Day/Event components
+provide a generic interface that can be used when defining them so type-safety is guaranteed.

--- a/apps/schedulely-docs/docs/Usage/Events.md
+++ b/apps/schedulely-docs/docs/Usage/Events.md
@@ -1,0 +1,35 @@
+---
+title: Events
+description: Event model and usage
+---
+
+| Property | Type     | Description                                                                                                |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| id       | `string` | Unique ID of this event                                                                                    |
+| start    | `string` | JS ISO Formatted that represents the start of the event                                                    |
+| end      | `string` | JS ISO Formatted that represents the end of the event                                                      |
+| summary  | `string` | String value that will appear in the default event component                                               |
+| color    | `string` | Color value that determines the color of the default event component. Can be any valid CSS color value.    |
+| data     | `object` | Arbitrary event data that you want passed to the Event and Day components. Not used by default components. |
+
+## Default Event Type
+
+An array of `CalendarEvent` items is supplied to Schedulely within your React application. The standard event type is used by the default Scheduely Event and Day components.
+
+```tsx
+const storyEvents: CalendarEvent[] = [
+  {
+    color: '#4b578a',
+    end: '2022-09-09T16:07:22.292Z',
+    id: 'f147',
+    start: '2022-09-08T16:07:22.292Z',
+    summary: 'Craig Bishop',
+  },
+];
+
+<Schedulely events={storyEvents} dark={colorMode === 'dark'} theme={theme} />;
+```
+
+## Custom Event Metadata
+
+[See the Custom Event Data Page](/docs/Usage/CustomEventData).

--- a/apps/schedulely-docs/docs/Usage/Events.md
+++ b/apps/schedulely-docs/docs/Usage/Events.md
@@ -1,5 +1,5 @@
 ---
-title: Events
+title: Event Data
 description: Event model and usage
 ---
 
@@ -29,6 +29,12 @@ const storyEvents: CalendarEvent[] = [
 
 <Schedulely events={storyEvents} dark={colorMode === 'dark'} theme={theme} />;
 ```
+
+## Internal Implementation
+
+Once you pass in your array of events, it is transformed into an `InternalCalendarEvent`. This allows us to make consistent transformations from input string dates to `Date`-types, as well as perform any validations all at once. If you require additional metadata for your events, you will need to utilize [Custom Event Data](/docs/Usage/CustomEventData), and possibly create custom Day/Event components depending on your intended usage.
+
+**Any additional Event properties passed in that are not listed in the `CalendarEvent` type will be discarded and will not reach the Day/Event components.**
 
 ## Custom Event Metadata
 

--- a/apps/schedulely-docs/package.json
+++ b/apps/schedulely-docs/package.json
@@ -16,10 +16,10 @@
     "schedulely": "*"
   },
   "dependencies": {
-    "@docusaurus/core": "2.2.0",
-    "@docusaurus/plugin-google-gtag": "^2.2.0",
-    "@docusaurus/preset-classic": "2.2.0",
-    "@docusaurus/theme-live-codeblock": "^2.2.0",
+    "@docusaurus/core": "2.3.1",
+    "@docusaurus/plugin-google-gtag": "^2.3.1",
+    "@docusaurus/preset-classic": "2.3.1",
+    "@docusaurus/theme-live-codeblock": "^2.3.1",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
@@ -32,8 +32,8 @@
     "schedulely": "*"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.1.0",
-    "@tsconfig/docusaurus": "^1.0.5",
+    "@docusaurus/module-type-aliases": "2.3.1",
+    "@tsconfig/docusaurus": "^1.0.6",
     "typescript": "^4.7.4"
   },
   "browserslist": {
@@ -48,7 +48,7 @@
       "last 1 safari version"
     ]
   },
-  "overrides":{
+  "overrides": {
     "got": ">=11.8.5",
     "trim": ">=0.0.3"
   },

--- a/apps/schedulely-docs/sidebars.js
+++ b/apps/schedulely-docs/sidebars.js
@@ -30,7 +30,13 @@ const sidebars = {
       link: {
         type: 'generated-index',
       },
-      items: ['Usage/Actions', 'Usage/DateTime', 'Usage/Keyboard'],
+      items: [
+        'Usage/Events',
+        'Usage/CustomEventData',
+        'Usage/Actions',
+        'Usage/DateTime',
+        'Usage/Keyboard',
+      ],
     },
     {
       type: 'category',

--- a/apps/schedulely-docs/src/components/HomepageSchedulely/HomepageSchedulely.tsx
+++ b/apps/schedulely-docs/src/components/HomepageSchedulely/HomepageSchedulely.tsx
@@ -59,7 +59,7 @@ const HomepageSchedulely = () => {
             events={storyEvents}
             dark={colorMode === 'dark'}
             theme={theme}
-            initialDayOfWeekFormat={'small'}
+            actions={{ onEventClick: (event) => console.log(event) }}
           />
           <div className="resize-action-message">
             Test{' '}

--- a/apps/schedulely-docs/src/components/HomepageSchedulely/HomepageSchedulely.tsx
+++ b/apps/schedulely-docs/src/components/HomepageSchedulely/HomepageSchedulely.tsx
@@ -59,7 +59,10 @@ const HomepageSchedulely = () => {
             events={storyEvents}
             dark={colorMode === 'dark'}
             theme={theme}
-            actions={{ onEventClick: (event) => console.log(event) }}
+            actions={{
+              onEventClick: (event) => console.log(event),
+              onMoreEventsClick: (events) => console.log(events),
+            }}
           />
           <div className="resize-action-message">
             Test{' '}

--- a/apps/schedulely-docs/src/components/HomepageSchedulely/helpers.stories.ts
+++ b/apps/schedulely-docs/src/components/HomepageSchedulely/helpers.stories.ts
@@ -34,6 +34,10 @@ export const generateEvents = (
       end: end.toISOString(),
       summary,
       color,
+      data: {
+        randomAnimal: chance().animal(),
+        randomAddress: chance().address(),
+      },
     });
   }
   return events;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@docusaurus/core": "^2.3.1",
         "@fortawesome/free-brands-svg-icons": "^6.2.0"
       },
       "devDependencies": {
@@ -26,7 +27,7 @@
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "husky": "^8.0.1",
         "prettier": "latest",
-        "turbo": "1.7.0",
+        "turbo": "1.7.4",
         "typescript": "^4.8.3"
       },
       "engines": {
@@ -36,10 +37,10 @@
     "apps/schedulely-docs": {
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/plugin-google-gtag": "^2.2.0",
-        "@docusaurus/preset-classic": "2.2.0",
-        "@docusaurus/theme-live-codeblock": "^2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/plugin-google-gtag": "^2.3.1",
+        "@docusaurus/preset-classic": "2.3.1",
+        "@docusaurus/theme-live-codeblock": "^2.3.1",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
@@ -52,8 +53,8 @@
         "schedulely": "*"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@tsconfig/docusaurus": "^1.0.5",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@tsconfig/docusaurus": "^1.0.6",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -2106,18 +2107,18 @@
       "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA=="
     },
     "node_modules/@docsearch/css": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-      "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-      "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.4",
         "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.2",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2138,9 +2139,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2152,13 +2153,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/cssnano-preset": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2179,7 +2180,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -2225,15 +2226,10 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-    },
-    "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
-      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
+    "node_modules/@docusaurus/core/node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
+      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2244,15 +2240,15 @@
         "node": ">=16.14"
       }
     },
-    "node_modules/@docusaurus/cssnano-preset/node_modules/tslib": {
+    "node_modules/@docusaurus/core/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
+      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2262,19 +2258,19 @@
       }
     },
     "node_modules/@docusaurus/logger/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
-      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
+      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2298,18 +2294,17 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2323,17 +2318,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
-      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
+      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2352,42 +2347,23 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-blog/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
-      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
+      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2406,59 +2382,21 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
-      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.2.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
-      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
+      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2471,38 +2409,19 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
-      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
+      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2515,61 +2434,23 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-debug/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
-      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
+      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2577,18 +2458,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
-      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
+      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2599,41 +2480,45 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
+      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
       "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
-      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
+      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2646,69 +2531,32 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-sitemap/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
-      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
+      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/plugin-debug": "2.2.0",
-        "@docusaurus/plugin-google-analytics": "2.2.0",
-        "@docusaurus/plugin-google-gtag": "2.2.0",
-        "@docusaurus/plugin-sitemap": "2.2.0",
-        "@docusaurus/theme-classic": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-search-algolia": "2.2.0",
-        "@docusaurus/types": "2.2.0"
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/plugin-debug": "2.3.1",
+        "@docusaurus/plugin-google-analytics": "2.3.1",
+        "@docusaurus/plugin-google-gtag": "2.3.1",
+        "@docusaurus/plugin-google-tag-manager": "2.3.1",
+        "@docusaurus/plugin-sitemap": "2.3.1",
+        "@docusaurus/theme-classic": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-search-algolia": "2.3.1",
+        "@docusaurus/types": "2.3.1"
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2728,22 +2576,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
-      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
+      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2766,60 +2614,22 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
-      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.2.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-classic/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
-      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
+      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2827,6 +2637,7 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -2837,58 +2648,20 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
-      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.2.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/theme-live-codeblock": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-2.2.0.tgz",
-      "integrity": "sha512-4XRFxfZGcyqmbLmNbnbZ2ZOsoY7FYCJUZKsYW5yzhZYjmjGg7lkdJH5trt9otUoKBsZopBpPWvcDZwCu1SENYg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-2.3.1.tgz",
+      "integrity": "sha512-BCxDPjnXs98tgLSteZZYsor3WQR/xkoFRdrwMzp624nQ5P/LoGmwym/7XzbrYKObwn4E0ffUjp2RpSAOtn+JKw==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@philpl/buble": "^0.19.7",
         "clsx": "^1.2.1",
         "fs-extra": "^10.1.0",
@@ -2904,27 +2677,27 @@
       }
     },
     "node_modules/@docusaurus/theme-live-codeblock/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
-      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
+      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -2939,14 +2712,14 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
-      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
+      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2956,15 +2729,14 @@
       }
     },
     "node_modules/@docusaurus/theme-translations/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
-      "devOptional": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2981,12 +2753,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
       "dependencies": {
-        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -3014,9 +2787,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
-      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
+      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -3033,17 +2806,17 @@
       }
     },
     "node_modules/@docusaurus/utils-common/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
+      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
       "dependencies": {
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3053,14 +2826,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@docusaurus/utils/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.18",
@@ -6088,9 +5861,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.2.tgz",
-      "integrity": "sha512-eKvSM5hz5w9RcUowu8LnQ5v0KRrFLCvF4K3KF/Ab3VwCT726rWgZUWUIQUPjr9qDENUMukQ/IHZ7bGUVYRGP0g==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
+      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -9907,9 +9680,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.13.0.tgz",
-      "integrity": "sha512-GTgHqxvbQbNoUfkbdgHMVTY3bXVRJUWkfWEImZ2TPjln6nFlsYvu2fIVGWQmsa3qQ1ck0HwGq8OhS0wPCnsjMw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==",
       "engines": {
         "node": ">=6.0.0"
       },
@@ -18904,27 +18677,27 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.0.tgz",
-      "integrity": "sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.4.tgz",
+      "integrity": "sha512-8RLedDoUL0kkVKWEZ/RMM70BvKLyDFen06QuKKhYC2XNOfNKqFDqzIdcY/vGick869bNIWalChoy4O07k0HLsA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.7.0",
-        "turbo-darwin-arm64": "1.7.0",
-        "turbo-linux-64": "1.7.0",
-        "turbo-linux-arm64": "1.7.0",
-        "turbo-windows-64": "1.7.0",
-        "turbo-windows-arm64": "1.7.0"
+        "turbo-darwin-64": "1.7.4",
+        "turbo-darwin-arm64": "1.7.4",
+        "turbo-linux-64": "1.7.4",
+        "turbo-linux-arm64": "1.7.4",
+        "turbo-windows-64": "1.7.4",
+        "turbo-windows-arm64": "1.7.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.0.tgz",
-      "integrity": "sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.4.tgz",
+      "integrity": "sha512-ZyYrQlUl8K/mYN1e6R7bEhPPYjMakz0DYMaexkyD7TAijQtWmTSd4a+I7VknOYNEssnUZ/v41GU3gPV1JAzxxQ==",
       "cpu": [
         "x64"
       ],
@@ -18935,9 +18708,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.0.tgz",
-      "integrity": "sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.4.tgz",
+      "integrity": "sha512-CKIXg9uqp1a+Yeq/c4U0alPOqvwLUq5SBZf1PGYhGqJsfG0fRBtJfkUjHuBsuJIOGXg8rCmcGSWGIsIF6fqYuw==",
       "cpu": [
         "arm64"
       ],
@@ -18948,9 +18721,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.0.tgz",
-      "integrity": "sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.4.tgz",
+      "integrity": "sha512-RIUl4RUFFyzD2T024vL7509Ygwcw+SEa8NOwPfaN6TtJHK7RZV/SBP3fLNVOptG9WRLnOWX3OvsLMbiOqDLLyA==",
       "cpu": [
         "x64"
       ],
@@ -18961,9 +18734,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.0.tgz",
-      "integrity": "sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.4.tgz",
+      "integrity": "sha512-Bg65F0AjYYYxqE6RPf2H5TIGuA/EyWMeGOATHVSZOWAbYcnG3Ly03GZii8AHnUi7ntWBdjwvXf/QbOS1ayNB6A==",
       "cpu": [
         "arm64"
       ],
@@ -18974,9 +18747,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.0.tgz",
-      "integrity": "sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.4.tgz",
+      "integrity": "sha512-rTaV50XZ2BRxRHOHqt1UsWfeDmYLbn8UKE6g2D2ED+uW+kmnTvR9s01nmlGWd2sAuWcRYQyQ2V+O09VfKPKcQw==",
       "cpu": [
         "x64"
       ],
@@ -18987,9 +18760,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.0.tgz",
-      "integrity": "sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.4.tgz",
+      "integrity": "sha512-h8sxdKPvHTnWUPtwnYszFMmSO0P/iUUwmYY9n7iYThA71zSao28UeZ0H0Gw75cY3MPjvkjn2C4EBAUGPjuZJLw==",
       "cpu": [
         "arm64"
       ],
@@ -19076,9 +18849,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -19554,6 +19327,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3816,9 +3816,9 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz",
-      "integrity": "sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA=="
+      "version": "5.2.35",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.35.tgz",
+      "integrity": "sha512-WMGl70X/upKye9Ix0xQtaKzNsFJE6I4ZEexypk1gyiB5REQZv9BI3Stw8Tby25YSGJ7OuYG0+5oCnkv1A+3kRA=="
     },
     "node_modules/@mdx-js/mdx": {
       "version": "1.6.22",
@@ -6545,9 +6545,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -6559,10 +6559,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6572,61 +6572,36 @@
       }
     },
     "node_modules/browserslist-generator": {
-      "version": "1.0.66",
-      "resolved": "https://registry.npmjs.org/browserslist-generator/-/browserslist-generator-1.0.66.tgz",
-      "integrity": "sha512-aFDax4Qzh29DdyhHQBD2Yu2L5OvaDnvYFMbmpLrLwwaNK4H6dHEhC/Nxv93/+mfAA+a/t94ln0P2JZvHO6LZDA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/browserslist-generator/-/browserslist-generator-2.0.3.tgz",
+      "integrity": "sha512-3j8ogwvlBpOEDR3f5n1H2n5BWXqHPWi/Xm8EC1DPJy5BWl4WkSFisatBygH/L9AEmg0MtOfcR1QnMuM9XL28jA==",
       "dependencies": {
-        "@mdn/browser-compat-data": "^4.1.16",
+        "@mdn/browser-compat-data": "^5.2.33",
         "@types/object-path": "^0.11.1",
-        "@types/semver": "^7.3.9",
+        "@types/semver": "^7.3.13",
         "@types/ua-parser-js": "^0.7.36",
-        "browserslist": "4.20.2",
-        "caniuse-lite": "^1.0.30001328",
-        "isbot": "3.4.5",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001450",
+        "isbot": "^3.6.5",
         "object-path": "^0.11.8",
-        "semver": "^7.3.7",
-        "ua-parser-js": "^1.0.2"
+        "semver": "^7.3.8",
+        "ua-parser-js": "^1.0.33"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16.15.1",
+        "npm": ">=7.0.0",
+        "pnpm": ">=3.2.0",
+        "yarn": ">=1.13"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/wessberg/browserslist-generator?sponsor=1"
       }
     },
-    "node_modules/browserslist-generator/node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/browserslist-generator/node_modules/ua-parser-js": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.32.tgz",
-      "integrity": "sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+      "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6919,9 +6894,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001443",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001443.tgz",
-      "integrity": "sha512-jUo8svymO8+Mkj3qbUbVjR8zv8LUGpGkUM/jKvc9SO2BvjCI980dp9fQbf/dyLs6RascPzgR4nhAKFA4OHeSaA==",
+      "version": "1.0.30001451",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
       "funding": [
         {
           "type": "opencollective",
@@ -11976,9 +11951,9 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isbot": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.4.5.tgz",
-      "integrity": "sha512-+KD6q1BBtw0iK9aGBGSfxJ31/ZgizKRjhm8ebgJUBMx0aeeQuIJ1I72beCoIrltIZGrSm4vmrxRxrG5n1aUTtw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.5.tgz",
+      "integrity": "sha512-BchONELXt6yMad++BwGpa0oQxo/uD0keL7N15cYVf0A1oMIoNQ79OqeYdPMFWDrNhCqCbRuw9Y9F3QBjvAxZ5g==",
       "engines": {
         "node": ">=12"
       }
@@ -16888,9 +16863,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz",
-      "integrity": "sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.15.0.tgz",
+      "integrity": "sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17063,15 +17038,15 @@
       }
     },
     "node_modules/rollup-plugin-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-ts/-/rollup-plugin-ts-3.1.1.tgz",
-      "integrity": "sha512-Zm+cq11QVV6thgGdvrhz1tUQGN7pzK/jt2+6ttqfUaX1bk6QB4rFIHm/bW5O057eAXd1H8gBi47QFE0+tqMopw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-ts/-/rollup-plugin-ts-3.2.0.tgz",
+      "integrity": "sha512-KkTLVifkUexEiAXS9VtSjDrjKr0TyusmNJpb2ZTAzI9VuPumSu4AktIaVNnwv70iUEitHwZtET7OAM+5n1u1tg==",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.2",
         "@wessberg/stringutil": "^1.0.19",
         "ansi-colors": "^4.1.3",
         "browserslist": "^4.21.4",
-        "browserslist-generator": "^1.0.66",
+        "browserslist-generator": "^2.0.1",
         "compatfactory": "^2.0.9",
         "crosspath": "^2.0.0",
         "magic-string": "^0.27.0",
@@ -20420,11 +20395,11 @@
         "postcss": "^8.4.16",
         "react-test-renderer": "^17.0.2",
         "resize-observer-polyfill": "^1.5.1",
-        "rollup": "^3.10.0",
+        "rollup": "^3.15.0",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-progress": "^1.1.2",
-        "rollup-plugin-ts": "^3.1.1",
+        "rollup-plugin-ts": "^3.2.0",
         "sass": "^1.55.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "husky": "^8.0.1",
     "prettier": "latest",
-    "turbo": "1.7.0",
+    "turbo": "1.7.4",
     "typescript": "^4.8.3"
   },
   "engines": {
@@ -40,6 +40,7 @@
   },
   "packageManager": "npm@8.15.0",
   "dependencies": {
+    "@docusaurus/core": "^2.3.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.0"
   }
 }

--- a/packages/Schedulely/__stories__/Schedulely.stories.tsx
+++ b/packages/Schedulely/__stories__/Schedulely.stories.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import '../src/Schedulely.scss';
 
+import { EventComponent, SchedulelyProps } from '@/types/index';
 import { Schedulely } from '../src/Schedulely';
-import { SchedulelyProps } from '@/types/index';
 import { StoryDecorator, ThemeState, useLadleContext } from '@ladle/react';
 import { storyEvents } from './helpers';
 
@@ -72,6 +74,50 @@ export const MinimalTheme = () => {
       <Schedulely
         {...props}
         dark={globalState.theme === ThemeState.Dark}
+      ></Schedulely>
+    </div>
+  );
+};
+
+export const CustomEvents = () => {
+  const { globalState } = useLadleContext();
+
+  const props: SchedulelyProps = {
+    events: storyEvents,
+    theme: 'minimal',
+    initialDate: new Date().toISOString(),
+  };
+
+  const CustomEvent: EventComponent<{ animal: string; address: string }> = ({
+    event,
+    isHovered,
+    onClick,
+  }) => {
+    const classes = ['event'];
+    if (isHovered) classes.push('event-selected');
+
+    return (
+      <div
+        role={'listitem'}
+        data-eventid={event.id}
+        className={classes.join(' ')}
+        style={{
+          backgroundColor: event.color,
+        }}
+        title={event.data?.animal}
+        onClick={() => onClick(event)}
+      >
+        <div className="event-text-container">{`${event.summary} - ${event.data?.address}`}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ height: '100%', marginBottom: '5em' }}>
+      <Schedulely
+        {...props}
+        dark={globalState.theme === ThemeState.Dark}
+        schedulelyComponents={{ eventComponent: CustomEvent }}
       ></Schedulely>
     </div>
   );

--- a/packages/Schedulely/__stories__/helpers.ts
+++ b/packages/Schedulely/__stories__/helpers.ts
@@ -34,6 +34,10 @@ const generateEvents = (
       end: end.toISOString(),
       summary,
       color,
+      data: {
+        animal: chance().animal(),
+        address: chance().address(),
+      },
     });
   }
   return events;

--- a/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
@@ -7,8 +7,14 @@ import { createDefaultAdapter } from '@/dateAdapters/date';
 import { render } from '@testing-library/react';
 import { useCalendar } from '@/hooks';
 
+/**
+ * Many of the tests here are simply pass-through tests. We just make sure the DateAdapter is called with the correct args,
+ * since the DateAdapter is tested separately.
+ */
+
 const testDate = Chance().date();
 
+/** useEffect call requires calendar to be available */
 const testCalendarView = [
   [
     new Date(2020, 11, 27),
@@ -106,9 +112,11 @@ jest.mock<{ createDefaultAdapter: (Date: Date) => DateTimeAdapter }>(
   })
 );
 
+const testDateAdapter = createDefaultAdapter();
+
 const wrapper = ({ children }: { children: ReactNode }) => (
   <CalendarProvider
-    dateAdapter={createDefaultAdapter()}
+    dateAdapter={testDateAdapter}
     initialDate={testDate.toISOString()}
     calendarEvents={[]}
   >
@@ -153,6 +161,13 @@ describe('useCalendar', () => {
   it('isCurrentMonth should return correct value', () =>
     expect(isCurrentMonth).toHaveBeenCalledWith(testDate));
 
+  it('dateAdapter should return correct value', () => {
+    const { result } = fireHook();
+    act(() => {
+      expect(result.current.dateAdapter).toEqual(testDateAdapter);
+    });
+  });
+
   describe('daysOfWeek should be called with correct arguments', () => {
     it('for "small" size', () => {
       mockBreakpoint = 'small';
@@ -195,6 +210,10 @@ describe('useCalendar', () => {
     const { result } = fireHook();
     act(() => result.current.onPrevYear());
     expect(addMonthsToDate).toHaveBeenCalledWith(testDate, -12);
+  });
+
+  it.skip('calendarWithEvents should return correct value', () => {
+    // need to come up with a test case for this
   });
 
   it('throws when called outside of provider', () => {

--- a/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
@@ -1,12 +1,10 @@
 import { CalendarProvider } from '@/providers';
-import { ComponentSize } from '@/types';
+import { ComponentSize, DateTimeAdapter } from '@/types';
 import { ReactNode } from 'react';
-import { createDefaultAdapter } from '@/dateAdapters';
+import { createDefaultAdapter } from '@/dateAdapters/date';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useCalendar } from '@/hooks';
-
-/* These tests are expected to be ran against the default date adapter in the US locale */
 
 const mockOnMonthChangeClick = jest.fn();
 jest.mock('@/hooks/useActions', () => ({
@@ -22,6 +20,85 @@ jest.mock('@/hooks/useBreakpoint', () => ({
   })),
 }));
 
+const testCalendarView = [
+  [
+    new Date(2020, 11, 27),
+    new Date(2020, 11, 28),
+    new Date(2020, 11, 29),
+    new Date(2020, 11, 30),
+    new Date(2020, 11, 31),
+    new Date(2021, 0, 1),
+    new Date(2021, 0, 2),
+  ],
+  [
+    new Date(2021, 0, 3),
+    new Date(2021, 0, 4),
+    new Date(2021, 0, 5),
+    new Date(2021, 0, 6),
+    new Date(2021, 0, 7),
+    new Date(2021, 0, 8),
+    new Date(2021, 0, 9),
+  ],
+  [
+    new Date(2021, 0, 10),
+    new Date(2021, 0, 11),
+    new Date(2021, 0, 12),
+    new Date(2021, 0, 13),
+    new Date(2021, 0, 14),
+    new Date(2021, 0, 15),
+    new Date(2021, 0, 16),
+  ],
+  [
+    new Date(2021, 0, 17),
+    new Date(2021, 0, 18),
+    new Date(2021, 0, 19),
+    new Date(2021, 0, 20),
+    new Date(2021, 0, 21),
+    new Date(2021, 0, 22),
+    new Date(2021, 0, 23),
+  ],
+  [
+    new Date(2021, 0, 24),
+    new Date(2021, 0, 25),
+    new Date(2021, 0, 26),
+    new Date(2021, 0, 27),
+    new Date(2021, 0, 28),
+    new Date(2021, 0, 29),
+    new Date(2021, 0, 30),
+  ],
+  [
+    new Date(2021, 0, 31),
+    new Date(2021, 1, 1),
+    new Date(2021, 1, 2),
+    new Date(2021, 1, 3),
+    new Date(2021, 1, 4),
+    new Date(2021, 1, 5),
+    new Date(2021, 1, 6),
+  ],
+];
+
+const mockConvertIsoDate = jest.fn((isoDate: string) => testDate);
+const mockGetYear = jest.fn();
+const mockGetCalendarView = jest.fn(() => testCalendarView);
+jest.mock<{ createDefaultAdapter: (Date: Date) => DateTimeAdapter }>(
+  '@/dateAdapters/date',
+  () => ({
+    createDefaultAdapter: jest.fn<DateTimeAdapter, any>(() => ({
+      getCalendarView: mockGetCalendarView,
+      getDaysOfWeek: jest.fn(),
+      getMonthName: jest.fn(),
+      getYear: mockGetYear,
+      isSameMonth: jest.fn(),
+      isDateToday: jest.fn(),
+      addMonthsToDate: jest.fn(),
+      isEventInWeek: jest.fn(),
+      convertIsoToDate: mockConvertIsoDate,
+      isCurrentMonth: jest.fn(),
+      isDateBetween: jest.fn(),
+    })),
+  })
+);
+
 const testDate = new Date(2023, 1, 14);
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -36,42 +113,42 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 describe('useCalendar', () => {
   it('currentDate should return correct date', () => {
-    const { result } = renderHook(() => useCalendar(), { wrapper });
-    expect(result.current.currentDate).toEqual(testDate);
+    renderHook(() => useCalendar(), { wrapper });
+    expect(mockConvertIsoDate).toHaveBeenCalledWith(testDate.toISOString());
   });
 
   it('currentYear should return correct value', () => {
-    const { result } = renderHook(() => useCalendar(), { wrapper });
-    expect(result.current.currentYear).toEqual(testDate.getFullYear());
+    renderHook(() => useCalendar(), { wrapper });
+    expect(mockGetYear).toHaveBeenCalledWith(testDate);
   });
 
-  describe('currentMonth should return correct value', () => {
-    it('for "small" size', () => {
-      mockBreakpoint = 'small';
-      const { result } = renderHook(() => useCalendar(), { wrapper });
-      expect(result.current.currentMonth).toEqual('Feb');
-    });
+  // describe('currentMonth should return correct value', () => {
+  //   it('for "small" size', () => {
+  //     mockBreakpoint = 'small';
+  //     const { result } = renderHook(() => useCalendar(), { wrapper });
+  //     expect(result.current.currentMonth).toEqual('Feb');
+  //   });
 
-    it('for "medium" size', () => {
-      mockBreakpoint = 'medium';
-      const { result } = renderHook(() => useCalendar(), { wrapper });
-      expect(result.current.currentMonth).toEqual('February');
-    });
+  //   it('for "medium" size', () => {
+  //     mockBreakpoint = 'medium';
+  //     const { result } = renderHook(() => useCalendar(), { wrapper });
+  //     expect(result.current.currentMonth).toEqual('February');
+  //   });
 
-    it('for "large" size', () => {
-      mockBreakpoint = 'large';
-      const { result } = renderHook(() => useCalendar(), { wrapper });
-      expect(result.current.currentMonth).toEqual('February');
-    });
-  });
+  //   it('for "large" size', () => {
+  //     mockBreakpoint = 'large';
+  //     const { result } = renderHook(() => useCalendar(), { wrapper });
+  //     expect(result.current.currentMonth).toEqual('February');
+  //   });
+  // });
 
-  /* The expected result of this test changes depending on if the current month is the same as the test month */
-  it('isCurrentMonth should return correct value', () => {
-    const { result } = renderHook(() => useCalendar(), { wrapper });
-    expect(result.current.isCurrentMonth).toEqual(
-      testDate.getMonth() === new Date().getMonth()
-    );
-  });
+  // /* The expected result of this test changes depending on if the current month is the same as the test month */
+  // it('isCurrentMonth should return correct value', () => {
+  //   const { result } = renderHook(() => useCalendar(), { wrapper });
+  //   expect(result.current.isCurrentMonth).toEqual(
+  //     testDate.getMonth() === new Date().getMonth()
+  //   );
+  // });
 
   it('throws when called outside of provider', () => {
     const ExceptionWrapper = () => {

--- a/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useCalendar.spec.tsx
@@ -1,7 +1,42 @@
+import { CalendarProvider } from '@/providers';
+import { ComponentSize } from '@/types';
+import { ReactNode } from 'react';
+import { createDefaultAdapter } from '@/dateAdapters';
 import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { useCalendar } from '@/hooks';
 
+const mockOnMonthChangeClick = jest.fn();
+jest.mock('@/hooks/useActions', () => ({
+  useActions: jest.fn(() => ({
+    onMonthChangeClick: mockOnMonthChangeClick,
+  })),
+}));
+
+const mockBreakpoint: ComponentSize = 'large';
+jest.mock('@/hooks/useBreakpoint', () => ({
+  useBreakpoint: jest.fn(() => ({
+    breakpoint: mockBreakpoint,
+  })),
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <CalendarProvider
+    dateAdapter={createDefaultAdapter()}
+    initialDate={new Date(2023, 1, 14).toISOString()}
+    calendarEvents={[]}
+  >
+    {children}
+  </CalendarProvider>
+);
+
 describe('useCalendar', () => {
+  it('currentDate should return correct date', () => {
+    const { result } = renderHook(() => useCalendar(), { wrapper });
+
+    expect(result.current.currentDate).toEqual(new Date(2023, 1, 14));
+  });
+
   it('throws when called outside of provider', () => {
     const ExceptionWrapper = () => {
       expect(useCalendar).toThrowError(/must be used within/);

--- a/packages/Schedulely/__tests__/hooks/useEventIntersection.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useEventIntersection.spec.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
 import { useEventIntersection } from '@/hooks';
 
+/** There isn't a great way to test this due to it relying so heavily on actual rendered container sizes. */
+
 describe('useEventIntersection', () => {
   it('throws when called outside of provider', () => {
     const ExceptionWrapper = () => {

--- a/packages/Schedulely/package.json
+++ b/packages/Schedulely/package.json
@@ -65,11 +65,11 @@
     "postcss": "^8.4.16",
     "react-test-renderer": "^17.0.2",
     "resize-observer-polyfill": "^1.5.1",
-    "rollup": "^3.10.0",
+    "rollup": "^3.15.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-progress": "^1.1.2",
-    "rollup-plugin-ts": "^3.1.1",
+    "rollup-plugin-ts": "^3.2.0",
     "sass": "^1.55.0"
   }
 }

--- a/packages/Schedulely/src/providers/CalendarProvider.tsx
+++ b/packages/Schedulely/src/providers/CalendarProvider.tsx
@@ -71,7 +71,7 @@ export const CalendarProvider = ({
     () => dateAdapter.getCalendarView(currentDate),
     [currentDate, dateAdapter]
   );
-
+  //test
   const events = useMemo(
     () =>
       calendarEvents

--- a/packages/Schedulely/src/providers/CalendarProvider.tsx
+++ b/packages/Schedulely/src/providers/CalendarProvider.tsx
@@ -75,14 +75,15 @@ export const CalendarProvider = ({
   const events = useMemo(
     () =>
       calendarEvents
-        .map((x) => {
+        .map(({ start, end, color, id, summary, data }) => {
           const internalEvent: InternalCalendarEvent = {
-            start: dateAdapter.convertIsoToDate(x.start),
-            end: dateAdapter.convertIsoToDate(x.end),
-            color: x.color,
-            id: x.id,
-            summary: x.summary,
+            start: dateAdapter.convertIsoToDate(start),
+            end: dateAdapter.convertIsoToDate(end),
+            color,
+            id,
+            summary,
             visible: false,
+            data,
           };
           return internalEvent;
         })

--- a/packages/Schedulely/src/providers/CalendarProvider.tsx
+++ b/packages/Schedulely/src/providers/CalendarProvider.tsx
@@ -71,7 +71,7 @@ export const CalendarProvider = ({
     () => dateAdapter.getCalendarView(currentDate),
     [currentDate, dateAdapter]
   );
-  //test
+
   const events = useMemo(
     () =>
       calendarEvents

--- a/packages/Schedulely/src/providers/CalendarProvider.tsx
+++ b/packages/Schedulely/src/providers/CalendarProvider.tsx
@@ -59,7 +59,6 @@ export const CalendarProvider = ({
     [currentDate, dateAdapter]
   );
 
-  // Does this need memo?
   const daysOfWeek = useMemo(() => {
     let format: 'long' | 'short' | 'narrow' = 'long';
     if (breakpoint === 'medium') format = 'short';

--- a/packages/Schedulely/src/types/InternalCalendarEvent.ts
+++ b/packages/Schedulely/src/types/InternalCalendarEvent.ts
@@ -1,7 +1,7 @@
 /**
  * This object represents an event that is supplied by the client
  */
-export interface CalendarEvent {
+export type CalendarEvent<T extends object = {}> = {
   /** Unique *external* ID of the event */
   id: string;
 
@@ -16,27 +16,24 @@ export interface CalendarEvent {
 
   /** Visible color of the event *(css color value)* */
   color: string;
-}
+
+  /** Optional event data object */
+  data?: T;
+};
 
 /**
- * This object represents an event that is displayed on the calendar
+ * This object is used internally to represent Events
  */
-export interface InternalCalendarEvent {
-  /** Unique *external* ID of the event */
-  id: string;
-
+export type InternalCalendarEvent<T extends object = {}> = Omit<
+  CalendarEvent<T>,
+  'start' | 'end'
+> & {
   /** Start date of the event */
   start: Date;
 
   /** End date of the event */
   end: Date;
 
-  /** Text that will be visible on the event */
-  summary: string;
-
-  /** Visible color of the event *(css color value)* */
-  color: string;
-
   /** Is this event visible (not hidden) */
   visible: boolean;
-}
+};

--- a/packages/Schedulely/src/types/SchedulelyComponents.ts
+++ b/packages/Schedulely/src/types/SchedulelyComponents.ts
@@ -1,7 +1,7 @@
 import { DayComponent, EventComponent, HeaderComponent } from '@/types';
 
 export interface SchedulelyComponents {
-  dayComponent: DayComponent;
+  dayComponent: DayComponent<any>;
   headerComponent: HeaderComponent;
-  eventComponent: EventComponent;
+  eventComponent: EventComponent<any>;
 }

--- a/packages/Schedulely/src/types/components/DayComponent.ts
+++ b/packages/Schedulely/src/types/components/DayComponent.ts
@@ -4,7 +4,7 @@ import { JSXElementConstructor, PropsWithChildren } from 'react';
 /**
  * Props interface for creating Day components
  */
-export interface DayComponentProps {
+export interface DayComponentProps<T extends object = {}> {
   /** Does this date represent the current month (used for coloring trailing/leading days) */
   isCurrentMonth: boolean;
 
@@ -15,10 +15,10 @@ export interface DayComponentProps {
   isOverflowed: boolean;
 
   /** Events occuring on this date */
-  events: InternalCalendarEvent[];
+  events: InternalCalendarEvent<T>[];
 
   /** Function executes when the more events indicator is clicked */
-  onMoreEventsClick: (event: InternalCalendarEvent[]) => void;
+  onMoreEventsClick: (event: InternalCalendarEvent<T>[]) => void;
 
   /** Function executes when the day container is clicked */
   onDayClick: (day: Date) => void;
@@ -30,6 +30,6 @@ export interface DayComponentProps {
 /**
  * Type used for creating DayComponent
  */
-export type DayComponent = JSXElementConstructor<
-  PropsWithChildren<DayComponentProps>
+export type DayComponent<T extends object = {}> = JSXElementConstructor<
+  PropsWithChildren<DayComponentProps<T>>
 >;

--- a/packages/Schedulely/src/types/components/EventComponent.ts
+++ b/packages/Schedulely/src/types/components/EventComponent.ts
@@ -4,18 +4,23 @@ import { JSXElementConstructor } from 'react';
 /**
  * Props interface for creating Event components
  */
-export interface EventComponentProps {
+export interface EventComponentProps<T extends object = {}> {
   /* The object that represents this event */
-  event: InternalCalendarEvent;
+  event: InternalCalendarEvent<T>;
 
   /* True when event is hovered. Can be used to control event display when spanning multiple weeks. */
   isHovered: boolean;
 
   /** Function executes when the event is clicked */
-  onClick: (event: InternalCalendarEvent) => void;
+  onClick: (event: InternalCalendarEvent<T>) => void;
 }
 
 /**
- * Type used for creating EventComponent
+ * Type used for creating EventComponent.
+ *
+ * *optional:* The `<T>` parameter is used to define the structure of the Event `data` property if required.
+ * This can be used to pass additional data into Event component.
  */
-export type EventComponent = JSXElementConstructor<EventComponentProps>;
+export type EventComponent<T extends object = {}> = JSXElementConstructor<
+  EventComponentProps<T>
+>;


### PR DESCRIPTION
- Allow for users to pass arbitrary, strongly-typed data with `CalendarEvents`
- Update some dependencies
- Update documentation to include custom data documentation
- Reorganize some of the documentation pages
- Add unit tests for `useCalendar` hook
- Tweak CI/CD pipeline so development branches build
- Update repo readme

Since the Custom event types are optional, this should be a non-breaking update.