### PR TITLE
Adds `weekStartsOn` as a DateAdaptor option

### DIFF
--- a/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
+++ b/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
@@ -2,6 +2,7 @@ import { DateTimeAdapter } from '@/types/index';
 import { createDefaultAdapter } from '@/dateAdapters/date';
 import {
   getAddMonthsToDateTestCases,
+  getCalendarViewTestCases,
   getDaysOfWeekTestCases,
   getIsSameMonthMonthTestCases,
   getIsTodayTestCases,
@@ -57,65 +58,16 @@ describe('Date Adapter', () => {
     });
 
     describe('getCalendarView', () => {
-      it('returns correct values (including sibling days)', () => {
-        const result = adapter.getCalendarView(new Date(2021, 0, 10));
-        expect(result).toEqual([
-          [
-            new Date(2020, 11, 27),
-            new Date(2020, 11, 28),
-            new Date(2020, 11, 29),
-            new Date(2020, 11, 30),
-            new Date(2020, 11, 31),
-            new Date(2021, 0, 1),
-            new Date(2021, 0, 2),
-          ],
-          [
-            new Date(2021, 0, 3),
-            new Date(2021, 0, 4),
-            new Date(2021, 0, 5),
-            new Date(2021, 0, 6),
-            new Date(2021, 0, 7),
-            new Date(2021, 0, 8),
-            new Date(2021, 0, 9),
-          ],
-          [
-            new Date(2021, 0, 10),
-            new Date(2021, 0, 11),
-            new Date(2021, 0, 12),
-            new Date(2021, 0, 13),
-            new Date(2021, 0, 14),
-            new Date(2021, 0, 15),
-            new Date(2021, 0, 16),
-          ],
-          [
-            new Date(2021, 0, 17),
-            new Date(2021, 0, 18),
-            new Date(2021, 0, 19),
-            new Date(2021, 0, 20),
-            new Date(2021, 0, 21),
-            new Date(2021, 0, 22),
-            new Date(2021, 0, 23),
-          ],
-          [
-            new Date(2021, 0, 24),
-            new Date(2021, 0, 25),
-            new Date(2021, 0, 26),
-            new Date(2021, 0, 27),
-            new Date(2021, 0, 28),
-            new Date(2021, 0, 29),
-            new Date(2021, 0, 30),
-          ],
-          [
-            new Date(2021, 0, 31),
-            new Date(2021, 1, 1),
-            new Date(2021, 1, 2),
-            new Date(2021, 1, 3),
-            new Date(2021, 1, 4),
-            new Date(2021, 1, 5),
-            new Date(2021, 1, 6),
-          ],
-        ]);
-      });
+      it.each(getCalendarViewTestCases(adapter.weekStartsOn))(
+        'returns correct values (including sibling days)',
+        ({ firstDayOfMonth, expected }) => {
+          const result = adapter.getCalendarView(
+            firstDayOfMonth,
+            adapter.weekStartsOn
+          );
+          expect(result).toEqual(expected);
+        }
+      );
     });
 
     describe('getDaysOfWeek', () => {

--- a/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
+++ b/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
@@ -21,6 +21,10 @@ const adapters = [
     name: 'Date',
     adapter: createDefaultAdapter(),
   },
+  {
+    name: 'DateWithStartOfWeek',
+    adapter: createDefaultAdapter('en', 'monday'),
+  },
 ];
 
 describe('Date Adapter', () => {
@@ -116,7 +120,7 @@ describe('Date Adapter', () => {
 
     describe('getDaysOfWeek', () => {
       it.each<{ format: 'long' | 'short' | 'narrow'; expected: string[] }>(
-        getDaysOfWeekTestCases()
+        getDaysOfWeekTestCases(adapter.weekStartsOn)
       )('with format "$format" returns $expected', ({ format, expected }) => {
         const result = adapter.getDaysOfWeek(format);
         expect(result).toEqual(expected);

--- a/packages/Schedulely/__tests__/testHelpers/dateAdapter.testHelper.ts
+++ b/packages/Schedulely/__tests__/testHelpers/dateAdapter.testHelper.ts
@@ -1,3 +1,4 @@
+import { WeekDay } from '../../src';
 import chance from 'chance';
 
 const DEFAULT_ITERATIONS = 30;
@@ -201,25 +202,51 @@ export const getMonthNameFromDateTestCases = () => [
   },
 ];
 
-export const getDaysOfWeekTestCases = () => [
-  {
-    format: 'long' as 'long' | 'short' | 'narrow',
-    expected: [
-      'Sunday',
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-    ],
-  },
-  {
-    format: 'short' as 'long' | 'short' | 'narrow',
-    expected: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-  },
-  {
-    format: 'narrow' as 'long' | 'short' | 'narrow',
-    expected: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  },
-];
+export const getDaysOfWeekTestCases = (weekStartsOn: WeekDay) =>
+  weekStartsOn === 'sunday'
+    ? [
+        {
+          format: 'long' as 'long' | 'short' | 'narrow',
+          expected: [
+            'Sunday',
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday',
+          ],
+        },
+        {
+          format: 'short' as 'long' | 'short' | 'narrow',
+          expected: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        },
+        {
+          format: 'narrow' as 'long' | 'short' | 'narrow',
+          expected: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+        },
+      ]
+    : weekStartsOn === 'monday'
+    ? [
+        {
+          format: 'long' as 'long' | 'short' | 'narrow',
+          expected: [
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday',
+            'Sunday',
+          ],
+        },
+        {
+          format: 'short' as 'long' | 'short' | 'narrow',
+          expected: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+        },
+        {
+          format: 'narrow' as 'long' | 'short' | 'narrow',
+          expected: ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
+        },
+      ]
+    : [];

--- a/packages/Schedulely/__tests__/testHelpers/dateAdapter.testHelper.ts
+++ b/packages/Schedulely/__tests__/testHelpers/dateAdapter.testHelper.ts
@@ -250,3 +250,121 @@ export const getDaysOfWeekTestCases = (weekStartsOn: WeekDay) =>
         },
       ]
     : [];
+
+export const getCalendarViewTestCases = (weekStartsOn: WeekDay) =>
+  weekStartsOn === 'sunday'
+    ? [
+        {
+          firstDayOfMonth: new Date(2021, 0, 10),
+          expected: [
+            [
+              new Date(2020, 11, 27),
+              new Date(2020, 11, 28),
+              new Date(2020, 11, 29),
+              new Date(2020, 11, 30),
+              new Date(2020, 11, 31),
+              new Date(2021, 0, 1),
+              new Date(2021, 0, 2),
+            ],
+            [
+              new Date(2021, 0, 3),
+              new Date(2021, 0, 4),
+              new Date(2021, 0, 5),
+              new Date(2021, 0, 6),
+              new Date(2021, 0, 7),
+              new Date(2021, 0, 8),
+              new Date(2021, 0, 9),
+            ],
+            [
+              new Date(2021, 0, 10),
+              new Date(2021, 0, 11),
+              new Date(2021, 0, 12),
+              new Date(2021, 0, 13),
+              new Date(2021, 0, 14),
+              new Date(2021, 0, 15),
+              new Date(2021, 0, 16),
+            ],
+            [
+              new Date(2021, 0, 17),
+              new Date(2021, 0, 18),
+              new Date(2021, 0, 19),
+              new Date(2021, 0, 20),
+              new Date(2021, 0, 21),
+              new Date(2021, 0, 22),
+              new Date(2021, 0, 23),
+            ],
+            [
+              new Date(2021, 0, 24),
+              new Date(2021, 0, 25),
+              new Date(2021, 0, 26),
+              new Date(2021, 0, 27),
+              new Date(2021, 0, 28),
+              new Date(2021, 0, 29),
+              new Date(2021, 0, 30),
+            ],
+            [
+              new Date(2021, 0, 31),
+              new Date(2021, 1, 1),
+              new Date(2021, 1, 2),
+              new Date(2021, 1, 3),
+              new Date(2021, 1, 4),
+              new Date(2021, 1, 5),
+              new Date(2021, 1, 6),
+            ],
+          ],
+        },
+      ]
+    : weekStartsOn === 'monday'
+    ? [
+        {
+          firstDayOfMonth: new Date(2021, 0, 10),
+          expected: [
+            [
+              new Date(2020, 11, 28),
+              new Date(2020, 11, 29),
+              new Date(2020, 11, 30),
+              new Date(2020, 11, 31),
+              new Date(2021, 0, 1),
+              new Date(2021, 0, 2),
+              new Date(2021, 0, 3),
+            ],
+            [
+              new Date(2021, 0, 4),
+              new Date(2021, 0, 5),
+              new Date(2021, 0, 6),
+              new Date(2021, 0, 7),
+              new Date(2021, 0, 8),
+              new Date(2021, 0, 9),
+              new Date(2021, 0, 10),
+            ],
+            [
+              new Date(2021, 0, 11),
+              new Date(2021, 0, 12),
+              new Date(2021, 0, 13),
+              new Date(2021, 0, 14),
+              new Date(2021, 0, 15),
+              new Date(2021, 0, 16),
+              new Date(2021, 0, 17),
+            ],
+            [
+              new Date(2021, 0, 18),
+              new Date(2021, 0, 19),
+              new Date(2021, 0, 20),
+              new Date(2021, 0, 21),
+              new Date(2021, 0, 22),
+              new Date(2021, 0, 23),
+              new Date(2021, 0, 24),
+            ],
+            [
+              new Date(2021, 0, 25),
+              new Date(2021, 0, 26),
+              new Date(2021, 0, 27),
+              new Date(2021, 0, 28),
+              new Date(2021, 0, 29),
+              new Date(2021, 0, 30),
+              new Date(2021, 0, 31),
+            ],
+          ],
+        },
+      ]
+    : [];

--- a/packages/Schedulely/src/dateAdapters/date.ts
+++ b/packages/Schedulely/src/dateAdapters/date.ts
@@ -1,18 +1,46 @@
-import { DateTimeAdapter } from '@/types';
+import { DateTimeAdapter, WeekDay, WeekDayNames } from '@/types';
 
 /**
  * Create an instance of the default date adapter
  * @param locale Locale override
  * @returns DateTimeAdapter
  */
-export const createDefaultAdapter = (locale = 'en'): DateTimeAdapter => {
-  const getDaysOfWeek = (format?: 'long' | 'short' | 'narrow') => {
+export const createDefaultAdapter = (
+  locale: string = 'en',
+  dayWeekStartsOn: WeekDay = 'sunday'
+): DateTimeAdapter => {
+  const getDaysOfWeek = (
+    format?: 'long' | 'short' | 'narrow',
+    weekStartsOn?: WeekDay
+  ) => {
+    const weekStart = weekStartsOn ? weekStartsOn : dayWeekStartsOn;
     const formatter = new Intl.DateTimeFormat(locale, {
       weekday: format,
     });
-    return [0, 1, 2, 3, 4, 5, 6].map((x) =>
+    const dates = [0, 1, 2, 3, 4, 5, 6].map((x) =>
       formatter.format(new Date(2012, 0, x + 1))
     );
+    // Get the formatted version of weekStartsOn
+    const formattedWeekStartsOn = new Intl.DateTimeFormat(locale, {
+      weekday: format,
+    }).format(new Date(Date.UTC(2012, 0, WeekDayNames.indexOf(weekStart) + 1)));
+
+    // Find the index of weekStartsOn in the array
+    const startDayIndex = dates.indexOf(formattedWeekStartsOn);
+
+    // Validate weekStartsOn input
+    if (startDayIndex === -1) {
+      throw new Error(
+        "weekStartsOn should be one of: 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'"
+      );
+    }
+
+    // Rotate the array until weekStartsOn is the first element
+    for (let i = 0; i < startDayIndex; i++) {
+      dates.push(dates.shift()!);
+    }
+
+    return dates;
   };
 
   /**
@@ -132,5 +160,6 @@ export const createDefaultAdapter = (locale = 'en'): DateTimeAdapter => {
     convertIsoToDate,
     isCurrentMonth,
     isDateBetween,
+    weekStartsOn: dayWeekStartsOn,
   };
 };

--- a/packages/Schedulely/src/dateAdapters/date.ts
+++ b/packages/Schedulely/src/dateAdapters/date.ts
@@ -50,16 +50,18 @@ export const createDefaultAdapter = (
    * @param date Native JS date object
    * @returns Date[][]
    */
-  const getCalendarView = (date: Date) => {
+  const getCalendarView = (date: Date, weekStartsOn?: WeekDay) => {
+    const weekStart = weekStartsOn ? weekStartsOn : dayWeekStartsOn;
+
     const startOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
     const endOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0);
 
-    const finalsOfPrevMonth = [];
-    const currentMonth = [];
-    const startsOfSchedulely = [];
+    const finalsOfPrevMonth: Date[] = [];
+    const currentMonth: Date[] = [];
+    const startsOfSchedulely: Date[] = [];
 
     let iteratedDate = startOfMonth;
-    while (iteratedDate.getDay() !== 0) {
+    while (iteratedDate.getDay() !== WeekDayNames.indexOf(weekStart)) {
       iteratedDate = new Date(
         iteratedDate.getFullYear(),
         iteratedDate.getMonth(),
@@ -79,8 +81,9 @@ export const createDefaultAdapter = (
     }
 
     iteratedDate = endOfMonth;
-    //only gather enough days until sunday
-    while (iteratedDate.getDay() + 1 !== 7) {
+    // only gather enough days until the the last day of the week
+    const lastDayCount = 7 - WeekDayNames.indexOf(weekStart);
+    while (iteratedDate.getDay() + 1 !== 7 - lastDayCount) {
       iteratedDate = new Date(
         iteratedDate.getFullYear(),
         iteratedDate.getMonth(),

--- a/packages/Schedulely/src/types/DateAdapter.ts
+++ b/packages/Schedulely/src/types/DateAdapter.ts
@@ -1,3 +1,5 @@
+import { WeekDay } from './WeekDay';
+
 /**
  * Common interface for porting date libraries so they can be used with Schedulely
  */
@@ -51,14 +53,3 @@ export interface DateTimeAdapter {
   /** What day of the week the week starts on, with 0 = Sunday, 1 = Monday, etc. */
   weekStartsOn: WeekDay;
 }
-
-export const WeekDayNames = [
-  'sunday',
-  'monday',
-  'tuesday',
-  'wednesday',
-  'thursday',
-  'friday',
-  'saturday',
-] as const;
-export type WeekDay = (typeof WeekDayNames)[number];

--- a/packages/Schedulely/src/types/DateAdapter.ts
+++ b/packages/Schedulely/src/types/DateAdapter.ts
@@ -6,7 +6,7 @@ export interface DateTimeAdapter {
   addMonthsToDate: (date: Date, amount: number) => Date;
 
   /** Returns all days in the month, split apart by week. Includes leading/trailing days. */
-  getCalendarView: (date: Date) => Date[][];
+  getCalendarView: (date: Date, weekStartsOn?: WeekDay) => Date[][];
 
   /**
    * Get names of all days of the week in the format specified
@@ -47,4 +47,18 @@ export interface DateTimeAdapter {
 
   /** Does the target date fall between the supplied dates */
   isDateBetween: (targetDate: Date, dateOne: Date, dateTwo: Date) => boolean;
+
+  /** What day of the week the week starts on, with 0 = Sunday, 1 = Monday, etc. */
+  weekStartsOn: WeekDay;
 }
+
+export const WeekDayNames = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+] as const;
+export type WeekDay = (typeof WeekDayNames)[number];

--- a/packages/Schedulely/src/types/WeekDay.ts
+++ b/packages/Schedulely/src/types/WeekDay.ts
@@ -1,0 +1,10 @@
+export const WeekDayNames = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+] as const;
+export type WeekDay = (typeof WeekDayNames)[number];

--- a/packages/Schedulely/src/types/index.ts
+++ b/packages/Schedulely/src/types/index.ts
@@ -8,5 +8,7 @@ export * from './InternalCalendarEvent';
 export * from './InternalEventWeek';
 export * from './SchedulelyComponents';
 export * from './SchedulelyProps';
+export * from './WeekDay';
 export * from './components/index';
 export * from './state/index';
+export * from './WeekDay';


### PR DESCRIPTION
With this `weekStartsOn` option, it's now possible for the consuming app to start what day of the week the calendar should start at.

The reason for this is currently it starts on a Sunday, regardless of your locale, so if you're in the UK (like I am), where our week starts on a Monday in the calendar, it looks off for us.

I've done this so it defaults to `sunday` so that no change in functionality is required, and no input is required from existing consumers of the package.