### PR TITLE
fix: Corrects the events passed into each day

### DIFF
--- a/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
+++ b/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
@@ -242,6 +242,12 @@ describe('Date Adapter', () => {
           dateTwo: new Date(2022, 1, 9),
           expected: true,
         },
+        {
+          targetDate: new Date('2023-07-26T23:00:00.000Z'),
+          dateOne: new Date('2023-07-27T06:00:00.000Z'),
+          dateTwo: new Date('2023-07-27T12:00:00.000Z'),
+          expected: true,
+        },
       ])(
         '$targetDate between $dateOne and $dateTwo returns $expected',
         ({ targetDate, dateOne, dateTwo, expected }) => {

--- a/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
+++ b/packages/Schedulely/__tests__/dateAdapters/dateAdapter.spec.ts
@@ -243,9 +243,9 @@ describe('Date Adapter', () => {
           expected: true,
         },
         {
-          targetDate: new Date('2023-07-26T23:00:00.000Z'),
-          dateOne: new Date('2023-07-27T06:00:00.000Z'),
-          dateTwo: new Date('2023-07-27T12:00:00.000Z'),
+          targetDate: new Date(2023, 6, 27, 0, 0, 0),
+          dateOne: new Date(2023, 6, 27, 6, 0, 0),
+          dateTwo: new Date(2023, 6, 27, 12, 0, 0),
           expected: true,
         },
       ])(

--- a/packages/Schedulely/__tests__/layouts/MonthLayout.spec.tsx
+++ b/packages/Schedulely/__tests__/layouts/MonthLayout.spec.tsx
@@ -111,12 +111,12 @@ vi.mock('@/providers', () => ({
   EventIntersectionProvider: vi.fn(
     ({
       children,
-      eventsInWeek,
+      eventsOnDays,
     }: {
       children: ReactNode;
-      eventsInWeek: InternalCalendarEvent[];
+      eventsOnDays: InternalEventWeek['eventsOnDays'];
     }) => {
-      mockEventIntersectionProviderPropsCheck(eventsInWeek);
+      mockEventIntersectionProviderPropsCheck(eventsOnDays);
       return <div data-testid="intersection-provider-mock">{children}</div>;
     }
   ),
@@ -181,7 +181,7 @@ describe('MonthLayout', () => {
         it('receives array of days', () => {
           expect(
             mockEventIntersectionProviderPropsCheck.mock.calls[week.index][0]
-          ).toEqual(mockCalendarWithEvents[week.index].events);
+          ).toEqual(mockCalendarWithEvents[week.index].eventsOnDays);
         });
       });
     }

--- a/packages/Schedulely/src/layouts/monthLayout/MonthLayout.tsx
+++ b/packages/Schedulely/src/layouts/monthLayout/MonthLayout.tsx
@@ -14,13 +14,13 @@ export const MonthLayout = () => {
   return (
     <div className="calendar-body-container">
       <HighlightProvider>
-        {calendarWithEvents.map(({ daysInWeek, events }, idx) => (
+        {calendarWithEvents.map(({ daysInWeek, events, eventsOnDays }, idx) => (
           <div
             key={daysInWeek[0].toISOString()}
             className="week-container"
             data-week={idx}
           >
-            <EventIntersectionProvider eventsInWeek={events}>
+            <EventIntersectionProvider eventsOnDays={eventsOnDays}>
               <EventWeekLayout eventsInWeek={events} daysInweek={daysInWeek} />
               <WeekLayout dates={daysInWeek} />
             </EventIntersectionProvider>

--- a/packages/Schedulely/src/providers/CalendarProvider.tsx
+++ b/packages/Schedulely/src/providers/CalendarProvider.tsx
@@ -125,12 +125,16 @@ export const CalendarProvider = ({
               x.start.valueOf() -
               (y.end.valueOf() - y.end.valueOf())
           ),
-        eventsOnDays: week.map((day) => ({
-          date: day,
-          events: events.filter(
-            (event) => event.start <= day && event.end >= day
-          ),
-        })),
+        eventsOnDays: week.map((day) => {
+          const endOfDay = new Date(day);
+          endOfDay.setDate(day.getDate() + 1);
+          return {
+            date: day,
+            events: events.filter((event) =>
+              dateAdapter.isDateBetween(day, event.start, event.end)
+            ),
+          };
+        }),
       })),
     [calendarView, events, dateAdapter]
   );


### PR DESCRIPTION
Ok, so what I think the problem here was, there were two places where the events for the day were being calculated, rather than just sticking to one. I've moved things around a little so that there is a single source of truth for events for the day, and that's calculated in the CalendarProvder, which is where I think it should be done. As such, I have removed some of the code from the EventIntersectionProvider, because that code seemed primarily to be about showing/hiding events, rather than what events it had. 

I've tested this with my own consuming project and with these changes, everything works as expected when I filter events out. 

Fixes: https://github.com/bruceharrison1984/Schedulely/issues/95