### PR TITLE
feat: Adds support for custom keyboard shortcut behaviour

### DIFF
--- a/packages/Schedulely/__stories__/Schedulely.stories.tsx
+++ b/packages/Schedulely/__stories__/Schedulely.stories.tsx
@@ -131,3 +131,34 @@ export const XXXCustomEvents = () => {
     </>
   );
 };
+
+export const XXXXCustomKeyboardHandlers = () => {
+  const { startOfWeek, events, theme } = useCalendarTester();
+
+  return (
+    <>
+      <CalendarStoryTester />
+      <div style={{ height: '100%', marginBottom: '5em' }}>
+        <Schedulely
+          {...defaultProps}
+          events={events}
+          dateAdapter={createDefaultAdapter('en', startOfWeek)}
+          dark={theme === ThemeState.Dark}
+          calendarOptions={{
+            keyboardEvents: {
+              onLeftArrow: () => console.log('left'),
+              onRightArrow: () => console.log('right'),
+              onUpArrow: () => console.log('up'),
+              onDownArrow: () => console.log('down'),
+            },
+          }}
+          actions={{
+            onMoreEventsClick: (events) => console.log(events),
+            onEventClick: (event) => console.log(event),
+            onDayClick: (day) => console.log(day),
+          }}
+        ></Schedulely>
+      </div>
+    </>
+  );
+};

--- a/packages/Schedulely/__tests__/hooks/useKeyboardControls.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useKeyboardControls.spec.tsx
@@ -1,3 +1,4 @@
+import { ActionProvider } from '../../src/providers';
 import { RenderResult, fireEvent, render } from '@testing-library/react';
 import { useKeyboardControls } from '@/hooks/useKeyboardControls';
 import { vi } from 'vitest';
@@ -15,9 +16,22 @@ vi.mock('@/hooks/useCalendar', () => ({
   })),
 }));
 
-const TestWrapper = () => {
+const mockOnUpArrow = vi.fn();
+const mockOnDownArrow = vi.fn();
+const mockOnLeftArrow = vi.fn();
+const mockOnRightArrow = vi.fn();
+
+const Wrapper = () => {
   useKeyboardControls();
   return <div></div>;
+};
+
+const TestWrapper = () => {
+  return (
+    <ActionProvider>
+      <Wrapper />
+    </ActionProvider>
+  );
 };
 
 describe('useKeyboardControls', () => {
@@ -45,5 +59,40 @@ describe('useKeyboardControls', () => {
   it('ArrowDown calls onPrevYear', () => {
     fireEvent.keyDown(testObject.container, { key: 'ArrowDown' });
     expect(mockOnPrevYear).toHaveBeenCalledTimes(1);
+  });
+
+  describe('custom keyboard events', () => {
+    beforeEach(() => {
+      vi.mock('@/hooks/useActions', () => ({
+        useActions: vi.fn(() => ({
+          keyboardEvents: {
+            onUpArrow: mockOnUpArrow,
+            onDownArrow: mockOnDownArrow,
+            onLeftArrow: mockOnLeftArrow,
+            onRightArrow: mockOnRightArrow,
+          },
+        })),
+      }));
+    });
+
+    it('ArrowUp calls onUpArrow', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowUp' });
+      expect(mockOnUpArrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowRight calls onRightArrow', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowRight' });
+      expect(mockOnRightArrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowLeft calls onLeftArrow', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowLeft' });
+      expect(mockOnLeftArrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowDown calls onDownArrow', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowDown' });
+      expect(mockOnDownArrow).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/Schedulely/__tests__/hooks/useKeyboardControls.spec.tsx
+++ b/packages/Schedulely/__tests__/hooks/useKeyboardControls.spec.tsx
@@ -1,4 +1,5 @@
-import { ActionProvider } from '../../src/providers';
+import { ActionProvider } from '../../src/providers/ActionProvider';
+import { KeyboardEvents } from '../../src';
 import { RenderResult, fireEvent, render } from '@testing-library/react';
 import { useKeyboardControls } from '@/hooks/useKeyboardControls';
 import { vi } from 'vitest';
@@ -26,9 +27,13 @@ const Wrapper = () => {
   return <div></div>;
 };
 
-const TestWrapper = () => {
+const TestWrapper = ({
+  keyboardEvents,
+}: {
+  keyboardEvents?: KeyboardEvents;
+}) => {
   return (
-    <ActionProvider>
+    <ActionProvider keyboardEvents={keyboardEvents}>
       <Wrapper />
     </ActionProvider>
   );
@@ -37,42 +42,42 @@ const TestWrapper = () => {
 describe('useKeyboardControls', () => {
   let testObject: RenderResult;
 
-  beforeEach(() => {
-    testObject = render(<TestWrapper />);
-  });
+  describe('default keyboard events', () => {
+    beforeEach(() => {
+      testObject = render(<TestWrapper />);
+    });
 
-  it('ArrowUp calls onNextYear', () => {
-    fireEvent.keyDown(testObject.container, { key: 'ArrowUp' });
-    expect(mockOnNextYear).toHaveBeenCalledTimes(1);
-  });
+    it('ArrowUp calls onNextYear', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowUp' });
+      expect(mockOnNextYear).toHaveBeenCalledTimes(1);
+    });
 
-  it('ArrowRight calls onNextMonth', () => {
-    fireEvent.keyDown(testObject.container, { key: 'ArrowRight' });
-    expect(mockOnNextMonth).toHaveBeenCalledTimes(1);
-  });
+    it('ArrowRight calls onNextMonth', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowRight' });
+      expect(mockOnNextMonth).toHaveBeenCalledTimes(1);
+    });
 
-  it('ArrowLeft calls onPrevMonth', () => {
-    fireEvent.keyDown(testObject.container, { key: 'ArrowLeft' });
-    expect(mockOnPrevMonth).toHaveBeenCalledTimes(1);
-  });
+    it('ArrowLeft calls onPrevMonth', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowLeft' });
+      expect(mockOnPrevMonth).toHaveBeenCalledTimes(1);
+    });
 
-  it('ArrowDown calls onPrevYear', () => {
-    fireEvent.keyDown(testObject.container, { key: 'ArrowDown' });
-    expect(mockOnPrevYear).toHaveBeenCalledTimes(1);
+    it('ArrowDown calls onPrevYear', () => {
+      fireEvent.keyDown(testObject.container, { key: 'ArrowDown' });
+      expect(mockOnPrevYear).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('custom keyboard events', () => {
     beforeEach(() => {
-      vi.mock('@/hooks/useActions', () => ({
-        useActions: vi.fn(() => ({
-          keyboardEvents: {
-            onUpArrow: mockOnUpArrow,
-            onDownArrow: mockOnDownArrow,
-            onLeftArrow: mockOnLeftArrow,
-            onRightArrow: mockOnRightArrow,
-          },
-        })),
-      }));
+      const keyboardEvents: KeyboardEvents = {
+        onUpArrow: mockOnUpArrow,
+        onDownArrow: mockOnDownArrow,
+        onLeftArrow: mockOnLeftArrow,
+        onRightArrow: mockOnRightArrow,
+      };
+
+      testObject = render(<TestWrapper keyboardEvents={keyboardEvents} />);
     });
 
     it('ArrowUp calls onUpArrow', () => {

--- a/packages/Schedulely/src/Schedulely.tsx
+++ b/packages/Schedulely/src/Schedulely.tsx
@@ -27,6 +27,7 @@ export const Schedulely = ({
   dark,
   eventPriority = EventPriority.long,
   initialDate = new Date().toISOString(),
+  calendarOptions = {},
 }: SchedulelyProps) => {
   if (!dateAdapter) throw new Error('Date Adapter must be supplied!');
 
@@ -56,7 +57,10 @@ export const Schedulely = ({
         ref={containerRef}
       >
         <BreakpointProvider containerRef={containerRef}>
-          <ActionProvider actions={actions}>
+          <ActionProvider
+            actions={actions}
+            keyboardEvents={calendarOptions.keyboardEvents}
+          >
             <ComponentProvider calendarComponents={schedulelyComponents}>
               <CalendarProvider
                 initialDate={initialDate}

--- a/packages/Schedulely/src/hooks/useKeyboardControls.tsx
+++ b/packages/Schedulely/src/hooks/useKeyboardControls.tsx
@@ -1,39 +1,64 @@
+import { useActions } from './useActions';
 import { useCalendar } from '@/hooks/useCalendar';
 import { useCallback, useEffect } from 'react';
 
 /**
  * Enables keyboard controls.
- * TODO: This could be expanded to allow for users to pass in their own keybindings
  */
 export const useKeyboardControls = () => {
   const { onNextMonth, onNextYear, onPrevMonth, onPrevYear } = useCalendar();
+  const { keyboardEvents } = useActions();
 
   const navigatePrevMonth = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === 'ArrowLeft') onPrevMonth();
+      if (event.key === 'ArrowLeft') {
+        if (keyboardEvents?.onLeftArrow) {
+          keyboardEvents.onLeftArrow();
+        } else {
+          onPrevMonth();
+        }
+      }
     },
-    [onPrevMonth]
+    [onPrevMonth, keyboardEvents]
   );
 
   const navigatePrevYear = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === 'ArrowDown') onPrevYear();
+      if (event.key === 'ArrowDown') {
+        if (keyboardEvents?.onDownArrow) {
+          keyboardEvents.onDownArrow();
+        } else {
+          onPrevYear();
+        }
+      }
     },
-    [onPrevYear]
+    [onPrevYear, keyboardEvents]
   );
 
   const navigateNextMonth = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === 'ArrowRight') onNextMonth();
+      if (event.key === 'ArrowRight') {
+        if (keyboardEvents?.onRightArrow) {
+          keyboardEvents.onRightArrow();
+        } else {
+          onNextMonth();
+        }
+      }
     },
-    [onNextMonth]
+    [onNextMonth, keyboardEvents]
   );
 
   const navigateNextYear = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === 'ArrowUp') onNextYear();
+      if (event.key === 'ArrowUp') {
+        if (keyboardEvents?.onUpArrow) {
+          keyboardEvents.onUpArrow();
+        } else {
+          onNextYear();
+        }
+      }
     },
-    [onNextYear]
+    [onNextYear, keyboardEvents]
   );
 
   useEffect(() => {

--- a/packages/Schedulely/src/providers/ActionProvider.tsx
+++ b/packages/Schedulely/src/providers/ActionProvider.tsx
@@ -1,4 +1,4 @@
-import { ActionContextState } from '@/types';
+import { ActionContextState, KeyboardEvents } from '@/types';
 import { PropsWithChildren, createContext } from 'react';
 
 export const ActionContext = createContext<ActionContextState | null>(null);
@@ -6,6 +6,7 @@ ActionContext.displayName = 'ActionContext';
 
 interface ActionProviderProps {
   actions?: Partial<ActionContextState>;
+  keyboardEvents?: KeyboardEvents;
 }
 
 /**
@@ -18,6 +19,7 @@ interface ActionProviderProps {
 export const ActionProvider = ({
   children,
   actions,
+  keyboardEvents,
 }: PropsWithChildren<ActionProviderProps>) => {
   const defaultAction = () => null;
 
@@ -31,6 +33,7 @@ export const ActionProvider = ({
     onMoreEventsClick,
     onMonthChangeClick,
     onDayClick,
+    keyboardEvents,
   };
 
   return (

--- a/packages/Schedulely/src/types/SchedulelyProps.ts
+++ b/packages/Schedulely/src/types/SchedulelyProps.ts
@@ -6,6 +6,22 @@ import {
 } from '@/types';
 import { EventPriority } from './EventPriority';
 
+export interface KeyboardEvents {
+  /** Typically used to navigate to the previous month */
+  onLeftArrow?: () => void;
+  /** Typically used to navigate to the next month */
+  onRightArrow?: () => void;
+  /** Typically used to navigate to the next year */
+  onUpArrow?: () => void;
+  /** Typically used to navigate to the previous year */
+  onDownArrow?: () => void;
+}
+
+export interface CalendarOptions {
+  /** Provides a way to customise the keyboard actions within the calendar */
+  keyboardEvents?: KeyboardEvents;
+}
+
 /** Properties used to initialize Schedulely */
 export interface SchedulelyProps {
   /** DateAdapter used to process dates */
@@ -38,4 +54,7 @@ export interface SchedulelyProps {
    *
    * _Long is the default_ */
   eventPriority?: EventPriority;
+
+  /** Options to customize the calendar */
+  calendarOptions?: CalendarOptions;
 }

--- a/packages/Schedulely/src/types/state/ActionContextState.ts
+++ b/packages/Schedulely/src/types/state/ActionContextState.ts
@@ -1,4 +1,5 @@
 import { InternalCalendarEvent } from '../InternalCalendarEvent';
+import { KeyboardEvents } from '../SchedulelyProps';
 
 /** Represents the state of the ActionProvider */
 export interface ActionContextState {
@@ -13,4 +14,7 @@ export interface ActionContextState {
 
   /** function that will run whenever a day container on the calendar is clicked */
   onDayClick: (day: Date) => void;
+
+  /** Object that contains optional keyboard shortcut overrides */
+  keyboardEvents?: KeyboardEvents;
 }


### PR DESCRIPTION
Unsure if you will approve of the implementation, but taken a stab at this anyway, mainly because I need a way to control when the keyboard shortcuts work (I have a scenario in my app that means some should be disabled). 

Essentially this allows for developers to provide their own handlers for up/down/left/right keys being pressed. If provided, these will be called, and the internal defaults will _not_ be called.

I've also implemented this in such a way that it can kick start what was raised in https://github.com/bruceharrison1984/Schedulely/issues/107